### PR TITLE
Buttplug.io stroker support, reduce command rate, clamp command values

### DIFF
--- a/ButtplugManager.cs
+++ b/ButtplugManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BepInEx;
@@ -118,8 +118,10 @@ namespace UKButt
             {
                 foreach (var buttplugClientDevice in connectedDevices)
                 {
-                    if (!buttplugClientDevice.AllowedMessages.ContainsKey("VibrateCmd")) continue;
-                    buttplugClientDevice.SendVibrateCmd(currentSpeed * StrengthMultiplier);
+                    if (buttplugClientDevice.AllowedMessages.ContainsKey("VibrateCmd"))
+                    {
+                        buttplugClientDevice.SendVibrateCmd(Math.Min(currentSpeed * StrengthMultiplier, 1.0));
+                    }
                 }
                 _timeSinceVibeUpdate = 0;
             }

--- a/ButtplugManager.cs
+++ b/ButtplugManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BepInEx;
@@ -18,6 +18,7 @@ namespace UKButt
 
         public float currentSpeed = 0;
         public float currentRank = 0;
+        public float currentLinearTime = 0;
 
         private UnscaledTimeSince _unscaledTimeSinceVibes;
         private TimeSince _timeSinceVibes;
@@ -31,11 +32,29 @@ namespace UKButt
         private float StrengthMultiplier => PrefsManager.Instance == null ? 0.8f : PrefsManager.Instance.GetFloatLocal(UKButtProperties.Strength, 0.8f);
         public InputMode InputMode => (InputMode)PrefsManager.Instance.GetIntLocal(UKButtProperties.InputMode, (int)InputMode.Varied);
         public static bool ForwardPatchedEvents => Instance != null && Instance.InputMode == InputMode.Varied;
+        
+        private float LinearPosMin => PrefsManager.Instance == null ? 0.1f : PrefsManager.Instance.GetFloatLocal(UKButtProperties.LinearPosMin, 0.1f);
+        private float LinearPosMax => PrefsManager.Instance == null ? 0.9f : PrefsManager.Instance.GetFloatLocal(UKButtProperties.LinearPosMax, 0.9f);
+        private float LinearTimeMin => PrefsManager.Instance == null ? 0.3f : PrefsManager.Instance.GetFloatLocal(UKButtProperties.LinearTimeMin, 0.3f);
+        private float LinearTimeMax => PrefsManager.Instance == null ? 1.5f : PrefsManager.Instance.GetFloatLocal(UKButtProperties.LinearTimeMax, 1.5f);
+
+        private bool StrokeWhileIdle => PrefsManager.Instance == null ? false : PrefsManager.Instance.GetBoolLocal(UKButtProperties.StrokeWhileIdle, false);
+
+        // Toggle for movement direction state
+        private bool _moveMax = true;
+
+        // Current setting for stroke time, recalculated based on rank at the end of each stroke
+        private float _moveTime;
+
+        // Timer for calculating stroke command frequency
+        private TimeSince _timeSinceLastMove;
 
         private void Awake()
         {
             Logger.LogInfo("Initializing UKButt");
             Instance = this;
+            // Start at the slowest Linear time.
+            _moveTime = LinearTimeMax;
 
             var harmony = HarmonyLib.Harmony.CreateAndPatchAll(typeof(CameraPatch));
             harmony.PatchAll(typeof(CameraPatch)); // Intercepts shake calls
@@ -122,6 +141,31 @@ namespace UKButt
                     {
                         buttplugClientDevice.SendVibrateCmd(Math.Min(currentSpeed * StrengthMultiplier, 1.0));
                     }
+                    // Only trigger stroker movement if we're using continuous rank mode. Variable mode doesn't make sense for this.
+                    if (InputMode == InputMode.ContinuousRank && (StrokeWhileIdle || currentSpeed > 0.00001)) {
+                        if (buttplugClientDevice.AllowedMessages.ContainsKey("LinearCmd"))
+                        {
+                            if (_timeSinceLastMove > _moveTime)
+                            {
+                                _moveTime = Math.Max(LinearTimeMax - ((LinearTimeMax - LinearTimeMin) * (currentSpeed * StrengthMultiplier)), LinearTimeMin);
+                                buttplugClientDevice.SendLinearCmd((uint)(1000 * _moveTime), _moveMax ? LinearPosMin : LinearPosMax);
+                            }
+                        }
+                    } 
+                    else
+                    {
+                        // This resets our move time so that once MoveWhileIdle or speed goes > 1, we'll be sure to actually trigger a command.
+                        _moveTime = 0;
+                    }
+                }
+                // On the extremely rare chance someone has multiple linear devices, don't reset values
+                // until after commands have been sent to all of them.
+                //
+                // Also, don't run this if we're not stroking already.
+                if (_moveTime > 0 && _timeSinceLastMove > _moveTime)
+                {
+                    _timeSinceLastMove = 0;
+                    _moveMax = !_moveMax;
                 }
                 _timeSinceVibeUpdate = 0;
             }

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ or `ukbutt prefs` to get the list of all available preferences and how to change
 | `ukbutt.enableMenuHaptics`  | `bool`   | Whether to enable haptics in the main menu.                             | `true`                 |
 | `ukbutt.inputMode`          | `int`    | The current [InputMode](#inputmodes).                                   | `1`                    |
 | `ukbutt.strokeWhileIdle`    | `bool`   | If in menu or rank == 0, stroke at lowest speed (rank mode only)        | `false`                |
-| `ukbutt.LinearPosMin`       | `float`  | Lowest position for stroker movement (rank mode only)                   | `0.1`                  |
-| `ukbutt.LinearPosMax`       | `float`  | Highest position for stroker movement (rank mode only)                  | `0.9`                  |
-| `ukbutt.LinearTimeMin`      | `float`  | Stroker frequency timing in seconds (rank at ULTRAKILL, rank mode only) | `0.3`                  |
-| `ukbutt.LinearTimeMax`      | `float`  | Stroker frequency timing in seconds (rank at None/Idle, rank mode only) | `1.5`                  |
+| `ukbutt.linearPosMin`       | `float`  | Lowest position for stroker movement (rank mode only)                   | `0.1`                  |
+| `ukbutt.linearPosMax`       | `float`  | Highest position for stroker movement (rank mode only)                  | `0.9`                  |
+| `ukbutt.linearTimeMin`      | `float`  | Stroker frequency timing in seconds (rank at ULTRAKILL, rank mode only) | `0.3`                  |
+| `ukbutt.linearTimeMax`      | `float`  | Stroker frequency timing in seconds (rank at None/Idle, rank mode only) | `1.5`                  |
 
 ## InputModes
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,20 @@ or `ukbutt prefs` to get the list of all available preferences and how to change
 
 <!-- table -->
 
-| Key                         | Type     | Description                                                            | Default                |
-| --------------------------- | -------- | ---------------------------------------------------------------------- | ---------------------- |
-| `ukbutt.socketUri`          | `string` | The URI of the Intiface Server.                                        | `ws://localhost:12345` |
-| `ukbutt.strength`           | `float`  | The strength of the vibration.                                         | `0.8`                  |
-| `ukbutt.stickForSeconds`    | `float`  | The minimum duration of a vibration. (in seconds)                      | `2.0`                  |
-| `ukbutt.tapStickForSeconds` | `float`  | Same as above, but for events marked as subtle.                        | `0.2`                  |
-| `ukbutt.useUnscaledTime`    | `bool`   | Whether to use unscaled (real) time for the duration of the vibration. | `false`                |
-| `ukbutt.enableMenuHaptics`  | `bool`   | Whether to enable haptics in the main menu.                            | `true`                 |
-| `ukbutt.inputMode`          | `int`    | The current [InputMode](#inputmodes).                                  | `1`                    |
+| Key                         | Type     | Description                                                             | Default                |
+| --------------------------- | -------- | ----------------------------------------------------------------------- | ---------------------- |
+| `ukbutt.socketUri`          | `string` | The URI of the Intiface Server.                                         | `ws://localhost:12345` |
+| `ukbutt.strength`           | `float`  | The strength of the vibration.                                          | `0.8`                  |
+| `ukbutt.stickForSeconds`    | `float`  | The minimum duration of a vibration. (in seconds)                       | `2.0`                  |
+| `ukbutt.tapStickForSeconds` | `float`  | Same as above, but for events marked as subtle.                         | `0.2`                  |
+| `ukbutt.useUnscaledTime`    | `bool`   | Whether to use unscaled (real) time for the duration of the vibration.  | `false`                |
+| `ukbutt.enableMenuHaptics`  | `bool`   | Whether to enable haptics in the main menu.                             | `true`                 |
+| `ukbutt.inputMode`          | `int`    | The current [InputMode](#inputmodes).                                   | `1`                    |
+| `ukbutt.strokeWhileIdle`    | `bool`   | If in menu or rank == 0, stroke at lowest speed (rank mode only)        | `false`                |
+| `ukbutt.LinearPosMin`       | `float`  | Lowest position for stroker movement (rank mode only)                   | `0.1`                  |
+| `ukbutt.LinearPosMax`       | `float`  | Highest position for stroker movement (rank mode only)                  | `0.9`                  |
+| `ukbutt.LinearTimeMin`      | `float`  | Stroker frequency timing in seconds (rank at ULTRAKILL, rank mode only) | `0.3`                  |
+| `ukbutt.LinearTimeMax`      | `float`  | Stroker frequency timing in seconds (rank at None/Idle, rank mode only) | `1.5`                  |
 
 ## InputModes
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ or `ukbutt prefs` to get the list of all available preferences and how to change
 
 You can change the input mode in-game by using `prefs set_local int ukbutt.inputMode <index>`
 
+Mode interaction with hardware:
+
+* Varied
+  * Vibration will be triggered on certain actions, including shooting, doors, sliding, menu haptics (if set), etc...
+  * No effect on strokers
+* Continuous Rank
+  * Vibration speed or stroker oscillation frequency is set by current style rank. The higher the
+    rank, the faster the vibration or stroking.
+
 ## Support
 
 If you have issues installing or using Intiface Central, you can either [visit the Buttplug.io discord](https://discord.buttplug.io) or [DM the @buttplugio twitter account](https://twitter.com/buttplugio).

--- a/UKButtProperties.cs
+++ b/UKButtProperties.cs
@@ -21,6 +21,20 @@
         // Toggles
         public static readonly string UseUnscaledTime = "ukbutt.useUnscaledTime";
         public static readonly string EnableMenuHaptics = "ukbutt.enableMenuHaptics";
+
+        // Linear settings
+
+        // Extremities of Linear positions
+        public static readonly string LinearPosMin = "ukbutt.linearPosMin";
+        public static readonly string LinearPosMax = "ukbutt.linearPosMax";
+
+        // Time boundaries based on rank
+        public static readonly string LinearTimeMin = "ukbutt.linearTimeMin";
+        public static readonly string LinearTimeMax = "ukbutt.linearTimeMax";
+
+        // If true, stroker should always stroke at lowest speed, even while style rank
+        // is 0 or player is in menu.
+        public static readonly string StrokeWhileIdle = "ukbutt.strokeWhileIdle";
     }
     
     public enum InputMode { None = 0, Varied = 1, ContinuousRank = 2 }

--- a/ULTRAKILL/UKButt.cs
+++ b/ULTRAKILL/UKButt.cs
@@ -62,6 +62,41 @@ namespace UKButt.Commands
                     Type = typeof(int),
                     Default = "1"
                 },
+                new PrefReference
+                {
+                    Key = UKButtProperties.LinearPosMin,
+                    Local = true,
+                    Type = typeof(float),
+                    Default = "0.1"
+                },
+                new PrefReference
+                {
+                    Key = UKButtProperties.LinearPosMax,
+                    Local = true,
+                    Type = typeof(float),
+                    Default = "0.9"
+                },
+                new PrefReference
+                {
+                    Key = UKButtProperties.LinearTimeMin,
+                    Local = true,
+                    Type = typeof(float),
+                    Default = "0.3"
+                },
+                new PrefReference
+                {
+                    Key = UKButtProperties.LinearTimeMax,
+                    Local = true,
+                    Type = typeof(float),
+                    Default = "1.5"
+                },
+                new PrefReference
+                {
+                    Key = UKButtProperties.StrokeWhileIdle,
+                    Local = true,
+                    Type = typeof(bool),
+                    Default = "False"
+                },
             });
             
             Leaf("restart_client", () =>


### PR DESCRIPTION
A feature and a couple of "might make things work slightly better" things:

- Added a 10hz clamp on command frequency, because bluetooth LE is horrible. This may get changed again once our timing system reports better, as things like controller haptics can run way higher than 10hz.
- Clamped output values, 'cause > 1.0 makes buttplug whine (but it'll still run the commands and clamp at 1.0 internally)
- Added support for linear devices like the Kiiroo Keon and The Handy. Doubt many players will have these, but it'll make for a fun shitpost.

Expect fucking machine support sometime in the next week or so, that'll be a pretty easy change, just need to start working with the v3 spec, which requires C# client updates.